### PR TITLE
fix: fails to build with nil value in tags

### DIFF
--- a/content/doc/rules.dmark
+++ b/content/doc/rules.dmark
@@ -413,7 +413,7 @@ title: "Rules"
 
   #listing[lang=ruby]
     preprocess do
-      tags = @items.map { |i| i[:tags] %}.uniq
+      tags = @items.map { |i| i[:tags] %}.compact.uniq
       tags.each do |tag|
         content = ''
         attributes = { tag: tag %}


### PR DESCRIPTION
When a page does not have any tags, this will cause a `nil` to turn up in this array. By compacting it, these are removed.