### PR TITLE
Fix: remove duplicates

### DIFF
--- a/content/doc/rules.dmark
+++ b/content/doc/rules.dmark
@@ -413,7 +413,7 @@ title: "Rules"
 
   #listing[lang=ruby]
     preprocess do
-      tags = @items.map { |i| i[:tags] %}.uniq
+      tags = @items.map { |i| i[:tags] %}.compact.uniq
       tags.each do |tag|
         content = ''
         attributes = { tag: tag %}

--- a/content/doc/rules.dmark
+++ b/content/doc/rules.dmark
@@ -413,7 +413,7 @@ title: "Rules"
 
   #listing[lang=ruby]
     preprocess do
-      tags = @items.map { |i| i[:tags] %}.compact.uniq
+      tags = @items.map { |i| i[:tags] %}.compact.flatten.uniq
       tags.each do |tag|
         content = ''
         attributes = { tag: tag %}


### PR DESCRIPTION
Current content is an array of arrays, one array with tags from each page. Removing duplicates only removes duplicate sets of tags. A single tag may still occur in multiple of these inner arrays. By `#flatten`ing the array we make the `#uniq` do what it was probably intended to do.